### PR TITLE
Allow dim to be a tuple instead of int only

### DIFF
--- a/doatools/model/signals.py
+++ b/doatools/model/signals.py
@@ -4,7 +4,7 @@ from scipy.linalg import sqrtm
 from ..utils.math import randcn
 
 class SignalGenerator(ABC):
-    """Abstrace base class for all signal generators.
+    """Abstract base class for all signal generators.
     
     Extend this class to create your own signal generators.
     """
@@ -40,28 +40,33 @@ class ComplexStochasticSignal(SignalGenerator):
             3. A scalar if the covariance matrix is diagonal and all
                diagonal elements share the same value. In this case,
                parameter n must be specified.
-            
+
             Default value is `1.0`.
     """
 
-    def __init__(self, dim, C=1.0):
+    def __init__(self, dim, C=1.0, amplitudes=None):
         self._dim = dim
+        # returns input as a tuple if it isnt already
+        self._forceTuple = lambda x: x if type(x) is tuple else (x,)
+        print(type(dim), dim)
+        if amplitudes is not None:
+            C = amplitudes ** 2
         if np.isscalar(C):
             # Scalar
             self._C2 = np.sqrt(C)
-            self._generator = lambda n: self._C2 * randcn((self._dim, n))
+            self._generator = lambda n: self._C2 * randcn(self._forceTuple(self._dim) + (n,))
         elif C.ndim == 1:
             # Vector
             if C.size != dim:
                 raise ValueError('The size of C must be {0}.'.format(dim))
             self._C2 = np.sqrt(C).reshape((-1, 1))
-            self._generator = lambda n: self._C2 * randcn((self._dim, n))
+            self._generator = lambda n: self._C2 * randcn(self._forceTuple(self._dim) + (n,))
         elif C.ndim == 2:
             # Matrix
             if C.shape[0] != dim or C.shape[1] != dim:
                 raise ValueError('The shape of C must be ({0}, {0}).'.format(dim))
             self._C2 = sqrtm(C)
-            self._generator = lambda n: self._C2 @ randcn((self._dim, n))
+            self._generator = lambda n: self._C2 @ randcn((self._dim,) + n)
         else:
             raise ValueError(
                 'The covariance must be specified by a scalar, a vector of'

--- a/doatools/model/signals.py
+++ b/doatools/model/signals.py
@@ -44,13 +44,10 @@ class ComplexStochasticSignal(SignalGenerator):
             Default value is `1.0`.
     """
 
-    def __init__(self, dim, C=1.0, amplitudes=None):
+    def __init__(self, dim, C=1.0):
         self._dim = dim
         # returns input as a tuple if it isnt already
         self._forceTuple = lambda x: x if type(x) is tuple else (x,)
-        print(type(dim), dim)
-        if amplitudes is not None:
-            C = amplitudes ** 2
         if np.isscalar(C):
             # Scalar
             self._C2 = np.sqrt(C)


### PR DESCRIPTION
I got an error when I tried to use dim as a tuple in ComplexStochasticSignal.
I fixed it by adding a lambda function to ensure that calling randcn() works no matter if dim is an int or a tuple